### PR TITLE
DV-51: Update dependencies 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,11 +2,11 @@
 
 buildscript {
     repositories {
-        jcenter()
+        mavenCentral()
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.3.2'
+        classpath 'com.android.tools.build:gradle:4.2.2'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
@@ -16,7 +16,6 @@ buildscript {
 allprojects {
     repositories {
         mavenLocal()
-        jcenter()
         maven {
             url 'https://nexus.poynt.com/content/repositories/releases'
         }

--- a/codesamples/build.gradle
+++ b/codesamples/build.gradle
@@ -12,12 +12,12 @@ repositories {
 }
 
 android {
-    compileSdkVersion 28
-    buildToolsVersion "28.0.3"
+    compileSdkVersion 29
+    buildToolsVersion "29.0.3"
     defaultConfig {
         applicationId "co.poynt.samples.codesamples"
-        minSdkVersion 19
-        targetSdkVersion 23
+        minSdkVersion 21
+        targetSdkVersion 29
         versionCode 1
         versionName "1.0"
     }
@@ -41,8 +41,8 @@ android {
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
 
-    implementation 'co.poynt.api:android-api-model:1.2.260'
-    implementation 'co.poynt.android.sdk:poynt-sdk:1.3.20'
+    implementation 'co.poynt.api:android-api-model:1.2.288'
+    implementation 'co.poynt.android.sdk:poynt-sdk:1.3.21'
 
     implementation 'com.google.code.gson:gson:2.8.2'
 
@@ -59,10 +59,10 @@ dependencies {
 
     //compile 'com.google.zxing:zxing-parent:3.2.2-SNAPSHOT'
     //compile(group: 'com.google.zxing', name: 'zxing-parent', version: '3.2.1', ext: 'pom')
-    implementation 'com.journeyapps:zxing-android-embedded:3.0.2@aar'
-    implementation 'com.google.zxing:core:3.2.0'
+    implementation 'com.journeyapps:zxing-android-embedded:4.3.0@aar'
+    implementation 'com.google.zxing:core:3.4.1'
 
-    implementation 'com.jakewharton:butterknife:8.8.1'
-    annotationProcessor 'com.jakewharton:butterknife-compiler:8.8.1'
+    implementation 'com.jakewharton:butterknife:10.0.0'
+    annotationProcessor 'com.jakewharton:butterknife-compiler:10.0.0'
 
 }

--- a/codesamples/src/main/java/co/poynt/samples/codesamples/CameraActivity.java
+++ b/codesamples/src/main/java/co/poynt/samples/codesamples/CameraActivity.java
@@ -9,7 +9,7 @@ import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
 import android.os.Environment;
-import android.support.v4.app.ActivityCompat;
+import androidx.core.app.ActivityCompat;
 import android.util.Log;
 import android.view.MenuItem;
 import android.view.Surface;

--- a/codesamples/src/main/java/co/poynt/samples/codesamples/LoginActivity.java
+++ b/codesamples/src/main/java/co/poynt/samples/codesamples/LoginActivity.java
@@ -11,7 +11,7 @@ import android.app.ActionBar;
 import android.app.Activity;
 import android.content.pm.PackageManager;
 import android.os.Bundle;
-import android.support.v4.app.ActivityCompat;
+import androidx.core.app.ActivityCompat;
 import android.util.Log;
 import android.view.Menu;
 import android.view.MenuItem;

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,3 +16,4 @@
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
+android.useAndroidX=true

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.9.1-all.zip


### PR DESCRIPTION
This PR is to update the dependencies in the Poynt Samples.

Tested using below:
Android Studio - Hedgehog (2023.1.1 Patch 2) 
Java - openjdk-11.0.22
Gradle - 6.9.1
Gradle Plugin/Build Tools - 4.2.2
Android API model - co.poynt.api:android-api-model:1.2.288
Java SDK model - co.poynt.android.sdk:poynt-sdk:1.3.21

The gradle and gradle plugin versions have been kept low to serve as a reference for external apps as we have limitations on the versions that can be used to build an app and upload it successfully on the portal.