### PR TITLE
PA-3005: CT EMV fix 

### DIFF
--- a/codesamples/src/main/java/co/poynt/samples/codesamples/NonPaymentCardReaderActivity.java
+++ b/codesamples/src/main/java/co/poynt/samples/codesamples/NonPaymentCardReaderActivity.java
@@ -3120,6 +3120,7 @@ public class NonPaymentCardReaderActivity extends Activity {
     private void updateConnectionOptionsInterface(ConnectionOptions connectionOptions) {
         if (!newConnectionOptionLogic.isChecked()) {
             //nothing to do here. new logic is not enabled
+            connectionOptions.setEnabledInterfaces(ConnectionOptions.INTERFACE_NONE);
             return;
         }
 


### PR DESCRIPTION
https://poyntc.atlassian.net/browse/PA-3005

This crash happened:
 ```
Caused by: java.lang.NullPointerException: Attempt to invoke virtual method 'byte java.lang.Byte.byteValue()' on a null object reference
        at co.poynt.vendor.services.v1.IPoyntPaymentSPI$Stub$Proxy.checkCardPresence(IPoyntPaymentSPI.java:738)
        at co.poynt.services.PoyntCardReaderService$1$3.doInBackground(PoyntCardReaderService.java:141)
        at co.poynt.services.PoyntCardReaderService$1$3.doInBackground(PoyntCardReaderService.java:135)
```

We call method `paymentSPI.checkCardPresence` in `checkIfCardInserted` in PoyntServices. And second one is called from PoyntSamples. In `checkIfCardInserted` we also send `connectionOptions` and if "New connection option logic" is not enabled, than `Byte enabledInterfaces` field is `null` and it makes NPE.
The solution is to initialize `enabledInterfaces` as `ConnectionOptions.INTERFACE_NONE`.