### PR TITLE
NUAT-4402, PA-5196: removed setting "skipPaymentConfirmationScreen" parameteras true to avoid incorrect transaction behavior

### DIFF
--- a/codesamples/src/main/java/co/poynt/samples/codesamples/PaymentActivity.java
+++ b/codesamples/src/main/java/co/poynt/samples/codesamples/PaymentActivity.java
@@ -263,7 +263,6 @@ public class PaymentActivity extends Activity {
         payment.setReferences(generateReferences());
         payment.setSkipSignatureScreen(true);
         payment.setSkipReceiptScreen(true);
-        payment.setSkipPaymentConfirmationScreen(true);
         Intent collectPaymentIntent = new Intent(Intents.ACTION_COLLECT_PAYMENT);
         collectPaymentIntent.putExtra(Intents.INTENT_EXTRAS_PAYMENT, payment);
         startActivityForResult(collectPaymentIntent, COLLECT_PAYMENT_REFS_REQUEST);
@@ -436,7 +435,6 @@ public class PaymentActivity extends Activity {
 
         payment.setSkipSignatureScreen(true);
         payment.setSkipReceiptScreen(true);
-        payment.setSkipPaymentConfirmationScreen(true);
 
         payment.setCallerPackageName("co.poynt.sample");
         Map<String, String> processorOptions = new HashMap<>();


### PR DESCRIPTION
https://poyntc.atlassian.net/browse/NUAT-4402
https://godaddy-corp.atlassian.net/browse/PA-5196

# Fix:
Removing setting `payment.setSkipPaymentConfirmationScreen(true)`, because it creates an incorrect behavior during transaction cancelling. According to parameter description: "Displays processing screen as opposed to Thank you screen after a payment is complete", so in general it works as described, but add some confusion to all who uses it and naming of this parameter also confused. 
In future we will deprecate this parameter.
We have another parameter with correct and logical naming which may be used in future: `autoClose` or `skipReceiptScreen`.